### PR TITLE
Quick one-line bug fix: avoid NA's in version_issues.json

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: r.releases.internals
 Title: Internal Infrastructure for An R Universe of Package Releases
 Description: Internal infrastructure for an R universe of package releases.
-Version: 0.0.10
+Version: 0.0.11
 License: MIT + file LICENSE
 URL: https://github.com/r-releases/r.releases.internals
 BugReports: https://github.com/r-releases/r.releases.internals/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# r.releases.internals 0.0.11
+
+* Quick bug fix: avoid `NA` entries in `version_issues.json`.
+
 # r.releases.internals 0.0.10
 
 * Automatically merge GitLab URLs with non-"upcoming" releases.

--- a/R/record_versions.R
+++ b/R/record_versions.R
@@ -30,6 +30,7 @@ record_versions <- function(
   jsonlite::write_json(x = new, path = manifest, pretty = TRUE)
   aligned <- (new$version_current == new$version_highest) &
     (new$hash_current == new$hash_highest)
+  aligned[is.na(aligned)] <- TRUE
   new_issues <- new[!aligned,, drop = FALSE] # nolint
   jsonlite::write_json(x = new_issues, path = issues, pretty = TRUE)
   invisible()


### PR DESCRIPTION
@shikokuchuo, this is just a one-line bug fix to account to prevent `NA`s from showing up in https://github.com/r-releases/r-releases.r-universe.dev/blob/main/version_issues.json for newly-removed packages:

```json
[
  {
    "_row": "NA"
  },
  {
    "_row": "NA.1"
  },
  {
    "_row": "NA.2"
  },
  ...
```

I hope you don't mind if I get this out in a quick release. It is very trivial.