### PR TITLE
repo name and messages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: r.releases.internals
 Title: Internal Infrastructure for An R Universe of Package Releases
 Description: Internal infrastructure for an R universe of package releases.
-Version: 0.0.11
+Version: 0.0.12
 License: MIT + file LICENSE
 URL: https://github.com/r-releases/r.releases.internals
 BugReports: https://github.com/r-releases/r.releases.internals/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# r.releases.internals 0.0.12
+
+* Improve bot comment messages.
+* Change default contribution repo from `r-releases` to `contributions`.
+
 # r.releases.internals 0.0.11
 
 * Quick bug fix: avoid `NA` entries in `version_issues.json`.

--- a/R/assert_release_exists.R
+++ b/R/assert_release_exists.R
@@ -34,7 +34,7 @@ assert_release_github <- function(url) {
     x = releases
   )
   if (!length(releases)) {
-    return(paste("No full release found at URL", shQuote(url)))
+    return(no_release_message(url))
   }
 }
 
@@ -62,6 +62,28 @@ assert_release_gitlab <- function(url) {
     return(try_message(releases))
   }
   if (!nrow(releases) || !any(!releases$upcoming_release)) {
-    return(paste("No full release found at URL", shQuote(url)))
+    return(no_release_message(url))
   }
+}
+
+no_release_message <- function(url) {
+  github <- file.path(
+    "https://docs.github.com/en/repositories",
+    "releasing-projects-on-github/managing-releases-in-a-repository"
+  )
+  paste0(
+    "No full release found at URL ",
+    shQuote(url),
+    ". The R-releases project relies on GitHub/GitLab releases ",
+    "to distribute deployed versions of R packages, so we must ",
+    "ask that each contributed package host a release for its ",
+    "latest non-development version. ",
+    "For GitHub, maintainers can refer to ",
+    github,
+    " for instructions. For GitLab, the directions are at ",
+    "https://docs.gitlab.com/ee/user/project/releases/. ",
+    "Pre-releases (GitHub) and upcoming releases (GitLab) ",
+    "are ignored to ensure each release has the ",
+    "full endorsement of its maintainer."
+  )
 }

--- a/R/review_pull_request.R
+++ b/R/review_pull_request.R
@@ -16,7 +16,7 @@
 #'   in the repo.
 review_pull_request <- function(
   owner = "r-releases",
-  repo = "r-releases",
+  repo = "contributions",
   number
 ) {
   assert_character_scalar(owner)
@@ -56,7 +56,7 @@ review_pull_request <- function(
           "Pull request ",
           number,
           " attempts an action other than adding files in the 'packages/' ",
-          "folder. Manual review required."
+          "folder."
         )
       )
       return(invisible())
@@ -71,8 +71,7 @@ review_pull_request <- function(
           "Pull request ",
           number,
           " wrote something different than 1 URL for the file of package ",
-          shQuote(name),
-          ". Manual review required."
+          shQuote(name)
         )
       )
       return(invisible())
@@ -87,9 +86,8 @@ review_pull_request <- function(
         message = paste0(
           "Pull request ",
           number,
-          " automated diagnostics returned findings: ",
-          result,
-          ". Manual review required."
+          " automated checks returned findings: ",
+          result
         )
       )
       return(invisible())
@@ -133,7 +131,13 @@ pull_request_defer <- function(owner, repo, number, message) {
     owner = owner,
     repo = repo,
     number = number,
-    body = message
+    body = paste0(
+      message,
+      ". Your pull request has been marked for manual review. ",
+      "You can either wait for an R-releases moderator to review ",
+      "your contribution, or you can close this pull request ",
+      "and open a different one which passes automated checks."
+    )
   )
 }
 
@@ -167,8 +171,7 @@ pull_request_merge <- function(owner, repo, number) {
         number = number,
         body = paste0(
           "There was a problem merging pull request ",
-          number,
-          ". Manual review required. "
+          number
         )
       )
       gh::gh(
@@ -187,11 +190,10 @@ pull_request_merge <- function(owner, repo, number) {
       number = number,
       body = paste(
         "This pull request was automatically merged",
-        "to incorporate new packages in the r-releases universe.",
-        "An automated GitHub actions job will migrate the packages to",
-        "https://github.com/r-releases/r-releases.r-universe.dev.",
-        "You can check status and progress at",
-        "https://r-releases.r-universe.dev."
+        "to incorporate new packages into R-releases.",
+        "An automated GitHub actions job will deploy the packages",
+        "as described at https://r-releases.github.io/.",
+        "Thank you for your contribution."
       )
     )
   }

--- a/R/review_pull_requests.R
+++ b/R/review_pull_requests.R
@@ -7,7 +7,7 @@
 #' @inheritParams review_pull_request
 review_pull_requests <- function(
   owner = "r-releases",
-  repo = "r-releases"
+  repo = "contributions"
 ) {
   assert_character_scalar(owner)
   assert_character_scalar(repo)

--- a/man/review_pull_request.Rd
+++ b/man/review_pull_request.Rd
@@ -4,7 +4,7 @@
 \alias{review_pull_request}
 \title{Review a pull request.}
 \usage{
-review_pull_request(owner = "r-releases", repo = "r-releases", number)
+review_pull_request(owner = "r-releases", repo = "contributions", number)
 }
 \arguments{
 \item{owner}{Character of length 1, name of the universe repository owner.}

--- a/man/review_pull_requests.Rd
+++ b/man/review_pull_requests.Rd
@@ -4,7 +4,7 @@
 \alias{review_pull_requests}
 \title{Review pull requests.}
 \usage{
-review_pull_requests(owner = "r-releases", repo = "r-releases")
+review_pull_requests(owner = "r-releases", repo = "contributions")
 }
 \arguments{
 \item{owner}{Character of length 1, name of the universe repository owner.}


### PR DESCRIPTION
@shikokuchuo, this PR changes the default contribution repo from `r-releases` to `contributions`. It also improves the bot messages. In particular, if a package does not have a release, the message is much more verbose. As we discussed, not every maintainer has a habit of creating releases, so I think this will help moderators avoid repeating themselves.