### PR TITLE
Add explicit check that each contributed file has exactly 1 line

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: r.releases.internals
 Title: Internal Infrastructure for An R Universe of Package Releases
 Description: Internal infrastructure for an R universe of package releases.
-Version: 0.0.14
+Version: 0.0.15
 License: MIT + file LICENSE
 URL: https://github.com/r-releases/r.releases.internals
 BugReports: https://github.com/r-releases/r.releases.internals/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# r.releases.internals 0.0.15
+
+* Add explicit check that each contribution has only 1 line.
+
 # r.releases.internals 0.0.14
 
 * Allow terminating newline to be absent in URL contributions.

--- a/R/review_pull_request.R
+++ b/R/review_pull_request.R
@@ -75,7 +75,7 @@ review_pull_request <- function(
           number,
           "has",
           file$additions,
-          "lines. The file should have exactly 1 line",
+          "lines. The file must have exactly 1 line",
           "unless it contains custom JSON (which is uncommon)."
         )
       )

--- a/R/review_pull_request.R
+++ b/R/review_pull_request.R
@@ -63,6 +63,24 @@ review_pull_request <- function(
       return(invisible())
     }
     name <- basename(file$filename)
+    if (file$additions != 1L) {
+      pull_request_defer(
+        owner = owner,
+        repo = repo,
+        number = number,
+        message = paste(
+          "Text file",
+          shQuote(name),
+          "in pull request",
+          number,
+          "has",
+          file$additions,
+          "lines. The file should have exactly 1 line",
+          "unless it contains custom JSON (which is uncommon)."
+        )
+      )
+      return(invisible())
+    }
     if (!is_character_scalar(file$patch)) {
       pull_request_defer(
         owner = owner,


### PR DESCRIPTION
@shikokuchuo, after #39 I realized we needed an explicit check that a file has exactly 1 line. Rolling this in as part of #17.